### PR TITLE
Allow an additionalColors prop in the config

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -25,7 +25,7 @@ const cssWithDocs = (generator, config, mqs, fullConfig) => `${generator.docs(co
 ${generator.css(config, fullConfig)}`
 
 module.exports = (config, mediaQueries) => {
-  const colors = color(config.palette || config.colors)
+  const colors = color(Object.assign(config.palette || config.colors, config.additionalColors || {}))
 
   const skipModules = (config.skipModules || []).map(n => camel(n))
 


### PR DESCRIPTION
Currently if I want to add some extra colors it seems I need to specify them all plus the new colors. What do you think of the change to allow only specifying some more colors and keeping the defaults as well?